### PR TITLE
Create SQL INSERT glossary entry; fix typos in DELETE entry

### DIFF
--- a/content/sql/concepts/commands/delete.md
+++ b/content/sql/concepts/commands/delete.md
@@ -16,7 +16,7 @@ Catalog Content:
 
 ## Definition 
 
-Removes exisiting record(s) from a table. If a `WHERE` statement is excluded, all records in the table will be deleted.
+Removes existing record(s) from a table. If a `WHERE` statement is excluded, all records in the table will be deleted.
 
 ## Example
 
@@ -27,7 +27,7 @@ DELETE FROM students
 WHERE enrolled_status = 'not_current';
 ```
 
-Supoose we want to delete all entries in the `students` table:
+Suppose we want to delete all entries in the `students` table:
 
 ```sql
 DELETE FROM students;

--- a/content/sql/concepts/commands/insert.md
+++ b/content/sql/concepts/commands/insert.md
@@ -1,0 +1,58 @@
+---
+Title: "INSERT"
+Subjects:
+  - "Data Science"
+Tags:
+  - "Database"
+  - "Queries"
+  - "PostgreSQL"
+  - "MySQL"
+  - "SQLite"
+Catalog Content:
+  - "https://www.codecademy.com/learn/learn-sql"
+  - "https://www.codecademy.com/learn/paths/analyze-data-with-sql"
+  - "https://www.codecademy.com/learn/paths/design-databases-with-postgresql"
+---
+
+## Definition 
+
+Inserts new rows into a table.
+
+## Syntax
+
+```sql
+INSERT INTO table_name
+VALUES (value1, value2, ...);
+```
+
+Multiple rows can be inserted by adding additional sets to the `VALUES` clause:
+
+```sql
+INSERT INTO table_name
+VALUES 
+  (value1, value2, ...),
+  (value1, value2, ...);
+```
+
+To add values corresponding to only specific columns, thereby leaving the rest of the row as default values, specify them alongside the table name:
+
+```sql
+INSERT INTO table_name (column1, column2, ...)
+VALUES (value1, value2, ...);
+```
+
+Default values can also be added using the `DEFAULT` keyword for the relevant column value:
+
+```sql
+INSERT INTO table_name
+VALUES (value1, DEFAULT, value3, ...);
+```
+
+## Example
+
+The given query adds a new student to a `students` table, providing values for `first_name`, `last_name`, and `enrollment_date`, thereby inserting default values for all other columns:
+
+```sql
+INSERT INTO students (first_name, last_name, enrollment_date)
+VALUES ('Jeremy', 'Barbosa', '2016-09-01');
+```


### PR DESCRIPTION
New SQL glossary entry for INSERTs based on existing UPDATE and DELETE entries. Includes some errant typos I found while reading the DELETE entry.