### PR TITLE
Display Name -> Title

### DIFF
--- a/content/cpp/cpp.md
+++ b/content/cpp/cpp.md
@@ -1,5 +1,5 @@
 ---
-Display Name: "C++"
+Title: "C++"
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/c-plus-plus" 
 ---
 

--- a/content/css/css.md
+++ b/content/css/css.md
@@ -1,5 +1,5 @@
 ---
-Display Name: "CSS"
+Title: "CSS"
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/html-css" 
 ---
 

--- a/content/emojicode/emojicode.md
+++ b/content/emojicode/emojicode.md
@@ -1,7 +1,7 @@
 ---
 # This file is used to populate the hub page for the language whose folder it's in. Be sure to create a new version if you create a folder for a new language!
 
-Display Name: "Emojicode" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
+Title: "Emojicode" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
 Codecademy Hub Page: null # If codecademy.com doesn't have a hub page for this language, that's okay too. You can leave this field as `null`
 ---
 

--- a/content/git/git.md
+++ b/content/git/git.md
@@ -1,7 +1,7 @@
 ---
 # This file is used to populate the hub page for the language whose folder it's in. Be sure to create a new version if you create a folder for a new language!
 
-Display Name: "Git" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
+Title: "Git" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/bash" # If codecademy.com doesn't have a hub page for this language, that's okay too. You can leave this field as `null`
 ---
 

--- a/content/html/html.md
+++ b/content/html/html.md
@@ -1,5 +1,5 @@
 ---
-Display Name: "HTML"
+Title: "HTML"
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/html-css" 
 ---
 

--- a/content/java/java.md
+++ b/content/java/java.md
@@ -1,5 +1,5 @@
 ---
-Display Name: "Java"
+Title: "Java"
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/java" 
 ---
 

--- a/content/javascript/javascript.md
+++ b/content/javascript/javascript.md
@@ -1,5 +1,5 @@
 ---
-Display Name: "JavaScript"
+Title: "JavaScript"
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/javascript" 
 ---
 

--- a/content/markdown/markdown.md
+++ b/content/markdown/markdown.md
@@ -1,7 +1,7 @@
 ---
 # This file is used to populate the hub page for the language whose folder it's in. Be sure to create a new version if you create a folder for a new language!
 
-Display Name: "Markdown" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
+Title: "Markdown" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/bash" # If codecademy.com doesn't have a hub page for this language, that's okay too. You can leave this field as `null`
 ---
 

--- a/content/python/python.md
+++ b/content/python/python.md
@@ -1,5 +1,5 @@
 ---
-Display Name: "Python"
+Title: "Python"
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/python" 
 ---
 

--- a/content/ruby/ruby.md
+++ b/content/ruby/ruby.md
@@ -1,7 +1,7 @@
 ---
 # This file is used to populate the hub page for the language whose folder it's in. Be sure to create a new version if you create a folder for a new language!
 
-Display Name: "Ruby" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
+Title: "Ruby" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/ruby" # If codecademy.com doesn't have a hub page for this language, that's okay too. You can leave this field as `null`
 ---
 

--- a/content/sql/sql.md
+++ b/content/sql/sql.md
@@ -1,5 +1,5 @@
 ---
-Display Name: "SQL"
+Title: "SQL"
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/sql" 
 ---
 

--- a/content/swift/swift.md
+++ b/content/swift/swift.md
@@ -1,7 +1,7 @@
 ---
 # This file is used to populate the hub page for the language whose folder it's in. Be sure to create a new version if you create a folder for a new language!
 
-Display Name: "Swift" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
+Title: "Swift" # This is the name that appears on the hub page for this language. Pay attention to capitalization and punctuation!
 Codecademy Hub Page: "https://www.codecademy.com/catalog/language/swift" # If codecademy.com doesn't have a hub page for this language, that's okay too. You can leave this field as `null`
 ---
 


### PR DESCRIPTION
Changed the metadata field `Display Name` on topic files to `Title`, for consistency with topic and term files. They should now display correctly in the UI.

Looks like my text editor automatically added newlines to the end of each file I touched if there wasn't one already, so that would explain the rest of the diff.