### PR TITLE
Fix "strong type" typo in python data-types

### DIFF
--- a/content/python/concepts/data-types/data-types.md
+++ b/content/python/concepts/data-types/data-types.md
@@ -13,7 +13,7 @@ CatalogContent:
   - "paths/computer-science"
 ---
 
-Python is a strong type language. Strong type means that the data type of a value doesn't change in unexpected ways.
+Python is a strongly typed language. Strongly typed means that the data type of a value doesn't change in unexpected ways.
 
 ```py
 codecademy = 575


### PR DESCRIPTION
### Description

I don't see how the example showcases Python as strongly typed 😅... but regardless, the term is generally "strongly typed", not "strong type".

### Type of Change

<!--- Please check the boxes that are revelant to this PR: -->
- [ ] Adding a new entry
- [x] Editing an existing entry (fixing a typo, bug, issues, etc)
- [ ] Updating the documentation

### Checklist

- [x] My entry follows the Codecademy Docs style guide
- [x] I have performed a self-review of my own writing and code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my entry and corrected any misspellings
- [x] All writings are my own

