### PR TITLE
Added "license": "UNLICENSED" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
     "lint": "eslint \"./**.ts\" --max-warnings 0",
     "test": "jest"
   },
+  "license": "UNLICENSED",
   "version": "1.0.0"
 }


### PR DESCRIPTION
Per https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/licensing-a-repository#choosing-the-right-license we default to not being licensed. Per @li-codecademy we're going to have a CLA bot running soon, but in the meantime this makes it a bit more explicit.
