### PR TITLE
docs: added instructions for switching into and naming a new branch …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Contributing follows this workflow:
 
 1. Fork [this project repository](https://github.com/codecademy/docs).
 2. Clone the forked repository to your computer.
-3. Create a branch.
+3. Create, and switch into, a new branch.
 4. Edit or create an entry and commit the changes.
 5. Make a PR to merge your fork with this repo.
 
@@ -70,6 +70,7 @@ To link your Codecademy user profile to GitHub:
 ## Any tips for a Pull Request?
 
 - Keep your PRs byte-sized. No more than 3 new entries per PR!
+- Branch names should reflect the changes being pushed to the PR. (e.g. If we're adding 3 new entries for React, a proper branch name would be something like `add-three-react-entries`.)
 - All contributors must sign the Contributor License Agreement (CLA).
 - All required [status checks](https://docs.github.com/en/github/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) are expected to pass in each PR.
 - We require one approval from one [core team member](https://github.com/codecademy/docs#core-team) for each PR.


### PR DESCRIPTION
…for a PR.

### Description

Text added to `CONTRIBUTING.md` that explicitly instructs users to create, switch into, and push from a branch _separate_ from `main`. 

### Type of Change

This textual change was inspired by a recent comment from a user about pushing from a branch _not_ named `main`. When PRs that have changes pushed from a forked `main` branch, it was not a smooth experience creating a temporary branch on my local machine and fetching their changes for review. Inside, `CONTRIBUTING.md`, there was text added to the following sections to help clarify this matter: 

* "How do I submit a Pull Request (PR)?"
* "Any tips for a Pull Request?"

The text describes how a user should create _and_ switch into a new branch prior to making changes. Additionally, it offers the tip of naming a branch after the relatedness of the changes being made.

<!--- Please check the boxes that are relevant to this PR: -->

- [ ] Adding a new entry
- [ ] Editing an existing entry (fixing a typo, bug, issues, etc)
- [X] Updating the documentation

### Checklist

<!--- Please check the boxes that are relevant to this PR: -->

- [X] My entry follows the Codecademy Docs style guide
- [X] I have performed a self-review of my own writing and code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my entry and corrected any misspellings
- [X] All writings are my own

### Codecademy Username

@BrandonDusch 
https://www.github.com/Dusch4593
