### PR TITLE
fix: remove trailing spaces to pass lint and formatter

### DIFF
--- a/content/html/concepts/semantic-html/terms/details/details.md
+++ b/content/html/concepts/semantic-html/terms/details/details.md
@@ -22,7 +22,7 @@ There is a small triangle which shows the state of the element. By clicking on t
 The `<details>` element can be in two states, closed and open:
 
 - When in the closed state, only the content in the `<summary>` element is visible.
-- However, when the `<details>` element is toggled into an open state, the `<summary>` and any additional content inside the `<details>` element are visible. 
+- However, when the `<details>` element is toggled into an open state, the `<summary>` and any additional content inside the `<details>` element are visible.
 
 The `<details>` element must contain a `<summary>` element which will provide a label for the hidden additional details.
 

--- a/content/html/concepts/semantic-html/terms/details/details.md
+++ b/content/html/concepts/semantic-html/terms/details/details.md
@@ -38,8 +38,7 @@ The `<details>` element must contain a `<summary>` element which will provide a 
 ```html
 <!DOCTYPE html>
 <html>
-  <head>
-  </head>
+  <head> </head>
   <body>
     <!-- The details element -->
     <details>

--- a/content/html/concepts/semantic-html/terms/summary/summary.md
+++ b/content/html/concepts/semantic-html/terms/summary/summary.md
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/front-end-engineer-career-path'
 ---
 
-The `<summary>` semantic HTML element is used as a summary, label, or caption, for the `<details>` element. 
+The `<summary>` semantic HTML element is used as a summary, label, or caption, for the `<details>` element.
   
 Whether the `<details>` element is in an "open" or "closed" state, the `<summary>` text is always visible.
 

--- a/content/html/concepts/semantic-html/terms/summary/summary.md
+++ b/content/html/concepts/semantic-html/terms/summary/summary.md
@@ -14,7 +14,7 @@ CatalogContent:
 ---
 
 The `<summary>` semantic HTML element is used as a summary, label, or caption, for the `<details>` element.
-  
+
 Whether the `<details>` element is in an "open" or "closed" state, the `<summary>` text is always visible.
 
 ## Syntax
@@ -33,12 +33,14 @@ The `<summary>` element can only be used as a first child element of the `<detai
 ```html
 <!DOCTYPE html>
 <html>
-  <head>
-  </head>
+  <head> </head>
   <body>
     <details>
       <summary>Course Prerequisites</summary>
-      <p>To enroll in ECON 102, you must've passed ECON 101 in a previous semester.</p>
+      <p>
+        To enroll in ECON 102, you must've passed ECON 101 in a previous
+        semester.
+      </p>
       <!-- This can also include any other content e.g., images and GIFs -->
     </details>
   </body>


### PR DESCRIPTION
### Description
This will pass the tests for linting. There were 2 trailing spaces in the recent commits which have caused the tests to go red.
I have verified that `npm run lint` and `npm run format:all` and `npm run format:verify` pass locally.
@sonnynomnom 

### Type of Change

<!--- Please check the boxes that are relevant to this PR: -->

- [ ] Adding a new entry
- [X] Editing an existing entry (fixing a typo, bug, issues, etc)
- [ ] Updating the documentation

### Checklist

<!--- Please check the boxes that are relevant to this PR: -->

- [ ] My entry follows the Codecademy Docs style guide
- [ ] I have performed a self-review of my own writing and code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my entry and corrected any misspellings
- [ ] All writings are my own

### Codecademy Username

If you want your Codecademy username be displayed in your entry (feature coming in October), make sure to have your Codecademy user profile linked to your GitHub:

@lcart753

