### PR TITLE
fix: tests pass on windows locally with different path separator

### DIFF
--- a/content.test.ts
+++ b/content.test.ts
@@ -50,7 +50,7 @@ describe('Codecademy Docs Content', () => {
         if (fs.statSync(childPath).isDirectory()) {
           checkChild(childPath); // step into directory and make sure it's a valid child
         } else {
-          const nodeName = nodePath.split('/').slice(-1)[0];
+          const nodeName = nodePath.split(path.sep).slice(-1)[0];
           expect(childPath).toBe(path.join(nodePath, `${nodeName}.md`));
         }
       });


### PR DESCRIPTION
### Description

Fixes #225 

### Type of Change

<!--- Please check the boxes that are relevant to this PR: -->

- [ ] Adding a new entry
- [X] Editing an existing entry (fixing a typo, bug, issues, etc)
- [ ] Updating the documentation

### Checklist

<!--- Please check the boxes that are relevant to this PR: -->

- [X] My entry follows the Codecademy Docs style guide
- [X] I have performed a self-review of my own writing and code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my entry and corrected any misspellings
- [X] I have confirmed my changes are not being pushed from my forked `main` branch
- [X] I have confirmed that I'm pushing from a new branch named after the changes I'm making
- [X] All writings are my own

<!---
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is

If you want your Codecademy username to be displayed in your entry (feature coming in October), make sure to have your Codecademy user profile linked to your GitHub:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the GitHub field, add your GitHub profile URL.
-->
