### PR TITLE
update run-on-yarn to latest

### DIFF
--- a/.github/workflows/concept-of-the-week.yml
+++ b/.github/workflows/concept-of-the-week.yml
@@ -4,7 +4,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: Codecademy/run-on-yarn@v1
+      - uses: Codecademy/run-on-yarn@v1.1.0
         with:
           command: 'update-cotw'
       - name: 'Commit changes'


### PR DESCRIPTION
Update concept of the week job is still broken 😅

this just pulls in changes from https://github.com/Codecademy/run-on-yarn/pull/2 so that the bot uses a gh token