### PR TITLE
style: removed extra backticks

### DIFF
--- a/documentation/content-standards.md
+++ b/documentation/content-standards.md
@@ -105,13 +105,13 @@ console.log('Hello, World!');
 
 Currently, Codebytes supports the following languages:
 
-- C++: \```cpp
-- C#: \```csharp
-- Go: \```golang
-- JavaScript:\```javascript
-- PHP: \```php
-- Python: \```python
-- Ruby: \```ruby
+- C++: `cpp`
+- C#: `csharp`
+- Go: `golang`
+- JavaScript: `javascript`
+- PHP: `php`
+- Python: `python`
+- Ruby: `ruby`
 
 **Note:** Codebytes sometimes requires the code block to include some boilerplate code. To check what boilerplate is required for your language, select the language from the dropdown [in this demo page](https://www.codecademy.com/codebyte-editor). There you'll find a "Hello World!" program set up as an example!
 


### PR DESCRIPTION
Small edit in `content-standards.md` documentation in Codebytes section.

* Rather than precede with three backticks, decided to surround language constants with them so as not to confuse contributors into thinking it is written as \```javascript (incorrect) as opposed to \```codebyte/javascript (correct).