### PR TITLE
Correct typo in angular.md

### DIFF
--- a/content/general/concepts/angular/angular.md
+++ b/content/general/concepts/angular/angular.md
@@ -37,6 +37,6 @@ Angular uses the model-view-controller (MVC) pattern for structuring the code in
 
 ## Routing and Binding
 
-Single page applications (SPAs) are built with Angular and feature a URL that doesn't require a page reload to function. Agular uses routing is map the URL in the web browser to a specific state in the web application.
+Single page applications (SPAs) are built with Angular and feature a URL that doesn't require a page reload to function. Angular uses routing to map the URL in the web browser to a specific state in the web application.
 
 Angular also uses two-way data binding to inherently link the views and model data with one another. Updates in one causes updates in the other. This allows for data to be readily shared between components throughout the application.


### PR DESCRIPTION
Correcting grammar in the second to last paragraph.

### Description

This just corrects a typo I noticed when reading [Docs/General/Angular](https://www.codecademy.com/resources/docs/general/angular).

### Type of Change

- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] Under "Development" on the right, I have linked any issues that are relevant to this PR (write "Closes #<issue number> in the "Description" above).
