### PR TITLE
Add example of abs on a positive number

### DIFF
--- a/content/general/concepts/yukihiro-matsumoto/yukihiro-matsumoto.md
+++ b/content/general/concepts/yukihiro-matsumoto/yukihiro-matsumoto.md
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/code-foundations'
 ---
 
-![Yukihiro Matsumoto (Matz)](https://raw.githubusercontent.com/Codecademy/docs/main/media/Yukihiro_Matsumoto.png
+![Yukihiro Matsumoto (Matz)](https://raw.githubusercontent.com/Codecademy/docs/main/media/Yukihiro_Matsumoto.png)
 
 **Yukihiro "Matz" Matsumoto** (1965-present) is a software programmer and computer scientist widely known for his work as the chief designer of the [Ruby](https://www.codecademy.com/resources/docs/ruby) programming language. Blending parts of his favorite languages (Perl, Smalltalk, Eiffel, Ada, and Lisp), Matz formed Ruby into "a language of careful balance." As one of Japan's [open source](https://www.codecademy.com/resources/docs/open-source) evangelists, he has released products like [mruby](https://github.com/mruby/mruby) (a lightweight version of Ruby).
 

--- a/content/python/concepts/built-in-functions/terms/abs/abs.md
+++ b/content/python/concepts/built-in-functions/terms/abs/abs.md
@@ -1,6 +1,6 @@
 ---
 Title: 'abs()'
-Description: 'Takes in a numeric data type such as int or float and returns the absolute value of the argument.'
+Description: 'Returns the absolute value of a numeric argument.'
 Subjects:
   - 'Computer Science'
   - 'Data Science'
@@ -10,39 +10,37 @@ Tags:
   - 'Strings'
 CatalogContent:
   - 'learn-python-3'
-  - 'paths/computer-science'
   - 'paths/data-science'
 ---
 
-Takes in a numeric data type such as `int` or `float` and returns the absolute value of the argument.
+The `abs()` function returns the absolute value of a numeric argument.
 
 ## Syntax
 
-```py
+```pseudo
 abs(n)
 ```
 
-## Example 1
+Where n is a real number, for example an int or float, that will have its absolute value taken. The absolute value of n will be the non-negative value of n, a positive value will remain unchanged and a negative value will have its negative sign removed.
 
-Use `abs()` to return the absolute value of `-6.5`:
+## Example
 
-```py
-print(abs(-6.5))
-# Output: 6.5
-```
-
-## Example 2
-
-Use `abs()` to return the absolute value of `15`:
+In this example code, let's set up two variables; one positive number and one negative number; and print() the two.
 
 ```py
-print(abs(15))
-# Output: 15
+positive = 10
+negative = -3.5
+
+print(abs(positive))
+# Output: 10
+
+print(abs(negative))
+# Output: 3.5
 ```
 
-## Example 3
+## Codebyte Example
 
-Use `abs()` to return the absolute value of the `numbers` list:
+The following example returns the absolute value from each element in the `numbers` list:
 
 ```codebyte/python
 numbers = [-19.2, 27.3, 48, -115, 302.7, -421, -2011]

--- a/content/python/concepts/built-in-functions/terms/abs/abs.md
+++ b/content/python/concepts/built-in-functions/terms/abs/abs.md
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/data-science'
 ---
 
-The `abs()` function returns the absolute value of a numeric argument.
+The **`abs()`** function returns the absolute value of a numeric argument.
 
 ## Syntax
 
@@ -27,17 +27,22 @@ The absolute value of `n` will be its distance from zero regardless of its direc
 
 ## Example
 
-In this example code, let's set up two variables; one positive number and one negative number; and print() the two.
+In the example belwo, the absolute values of two variables, `positive` and `negative`, are returned with the `abs()` function:
 
 ```py
 positive = 10
 negative = -3.5
 
 print(abs(positive))
-# Output: 10
 
 print(abs(negative))
-# Output: 3.5
+```
+
+This will produce the following output:
+
+```shell
+10
+3.5
 ```
 
 ## Codebyte Example

--- a/content/python/concepts/built-in-functions/terms/abs/abs.md
+++ b/content/python/concepts/built-in-functions/terms/abs/abs.md
@@ -33,6 +33,15 @@ print(abs(-6.5))
 
 ## Example 2
 
+Use `abs()` to return the absolute value of `15`:
+
+```py
+print(abs(15))
+# Output: 15
+```
+
+## Example 3
+
 Use `abs()` to return the absolute value of the `numbers` list:
 
 ```codebyte/python

--- a/content/python/concepts/built-in-functions/terms/abs/abs.md
+++ b/content/python/concepts/built-in-functions/terms/abs/abs.md
@@ -21,7 +21,9 @@ The `abs()` function returns the absolute value of a numeric argument.
 abs(n)
 ```
 
-Where n is a real number, for example an int or float, that will have its absolute value taken. The absolute value of n will be the non-negative value of n, a positive value will remain unchanged and a negative value will have its negative sign removed.
+The return value will be the absolute value of the `n` parameter, which is of type `int` or `float`.
+
+The absolute value of `n` will be its distance from zero regardless of its direction (i.e., whether it is positive or negative). Since the absolute value is never negative, a positive value will remain unchanged and a negative value will have its negative sign removed
 
 ## Example
 


### PR DESCRIPTION
### Description

In \docs\content\python\concepts\built-in-functions\terms\abs changes abs.md to include an example of the function working on a positive number so that those who may not know what an absolute value is don't think that the abs python function simply reverses the sign of the input.

### Type of Change

- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] Under "Development" on the right, I have linked any issues that are relevant to this PR (write "Closes #<issue number> in the "Description" above).