### PR TITLE
Update `ContentCatalog` in Kotlin: Data Types

### DIFF
--- a/content/kotlin/concepts/data-types/data-types.md
+++ b/content/kotlin/concepts/data-types/data-types.md
@@ -10,7 +10,7 @@ Tags:
   - 'Boolean'
   - 'Characters'
 CatalogContent:
-  - 'learn-Kotlin'
+  - 'learn-kotlin'
   - 'paths/computer-science'
 ---
 


### PR DESCRIPTION
Typo fix for free course slug under `CatalogContent`.