### PR TITLE
Correct latex in cosh term

### DIFF
--- a/content/cpp/concepts/math-functions/terms/cosh/cosh.md
+++ b/content/cpp/concepts/math-functions/terms/cosh/cosh.md
@@ -26,7 +26,7 @@ If the magnitude of the result is too large to express, the function returns `HU
 The mathematical formula used in `cosh()` looks like this:
 
 ```tex
-cosh(x) = (e^x + e^{-x} )/2
+cosh(x) = \frac{e^x + e^{-x}}{2}
 ```
 
 ## Example

--- a/content/cpp/concepts/math-functions/terms/cosh/cosh.md
+++ b/content/cpp/concepts/math-functions/terms/cosh/cosh.md
@@ -26,7 +26,7 @@ If the magnitude of the result is too large to express, the function returns `HU
 The mathematical formula used in `cosh()` looks like this:
 
 ```tex
-cosh(x) = (e^x + e^-x )/2
+cosh(x) = (e^x + e^{-x} )/2
 ```
 
 ## Example


### PR DESCRIPTION
### Description

Update `cosh.md` to fix a typo. In the LaTeX, the exponent `-x` needs to be in curly braces to remain fully in the exponent. Also added `\frac` to make the rendering prettier.

### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist

<!-- Please check ALL the boxes: -->

- [ x] All writings are my own.
- [ x] My entry follows the Codecademy Docs style guide.
- [ x] My changes generate no new warnings.
- [ x] I have performed a self-review of my own writing and code.
- [ x] I have checked my entry and corrected any misspellings.
- [ x] I have made corresponding changes to the documentation if needed.
- [ x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ x] Under "Development" on the right, I have linked any issues that are relevant to this PR (write "Closes #<issue number> in the "Description" above).

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
