### PR TITLE
Fix typo in .toSpliced() method

### DIFF
--- a/content/javascript/concepts/arrays/terms/toSpliced/toSpliced.md
+++ b/content/javascript/concepts/arrays/terms/toSpliced/toSpliced.md
@@ -11,7 +11,7 @@ CatalogContent:
   - 'paths/front-end-engineer-career-path'
 ---
 
-**`.toSpliced()`** is a method that modifies multiple array elements. It has a start point (the first element to be modified) and an endpoint (the last element to be modified). `.toSpliced()` can make the following changes to an array:
+**`.toSpliced()`** is a method that modifies multiple array elements. It has a starting point (the first element to be modified) and an end point (the last element to be modified). `.toSpliced()` can make the following changes to an array:
 
 - Extract element(s)
 - Replace element(s)
@@ -33,7 +33,7 @@ myArray.toSpliced(startIndex, count, elementN)
 
 ## Examples
 
-### Extract Array Elements With `.toSpliced`
+### Extracting Array Elements
 
 ```js
 const colors = ['red', 'yellow', 'blue', 'orange', 'green', 'purple'];
@@ -49,7 +49,7 @@ console.log(colors);
 // Output: 'red', 'yellow', 'blue', 'orange', 'green', 'purple'
 ```
 
-### Replace Array Elements Using `.toSpliced()`
+### Replacing Array Elements
 
 ```js
 const colors = ['red', 'yellow', 'blue', 'orange', 'green', 'purple'];
@@ -70,7 +70,7 @@ console.log(colors);
 // Output: 'red', 'yellow', 'blue', 'orange', 'green', 'purple'
 ```
 
-### Insert New Items Into an Array Using `.toSpliced`
+### Inserting New Items Into an Array
 
 ```js
 const colors = ['red', 'yellow', 'blue', 'orange', 'green', 'purple'];

--- a/content/javascript/concepts/arrays/terms/toSpliced/toSpliced.md
+++ b/content/javascript/concepts/arrays/terms/toSpliced/toSpliced.md
@@ -54,7 +54,7 @@ console.log(colors);
 ```js
 const colors = ['red', 'yellow', 'blue', 'orange', 'green', 'purple'];
 
-// Replacing red, green, and yellow. Start at index 0, and replace three items.
+// Replacing red, yellow, and blue. Start at index 0, and replace three items.
 const tertiaryColors = colors.toSpliced(
   0,
   3,


### PR DESCRIPTION
### Description

This PR fixes a typo in a comment regarding the elements of a list.

Linked to the merged PR #2910.

### Type of Change

- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] Under "Development" on the right, I have linked any issues that are relevant to this PR (write "Closes #<issue number> in the "Description" above).
