### PR TITLE
Swift Structures: Fixed the braces so that link shows correctly in ../swift/structures/structures.md file.

### DIFF
--- a/content/swift/concepts/structures/structures.md
+++ b/content/swift/concepts/structures/structures.md
@@ -28,7 +28,7 @@ struct Building {
 }
 ```
 
-> **Note:** All stored properties of structures must conform to [Hashable]{https://developer.apple.com/documentation/swift/hashable} Protocol.
+> **Note:** All stored properties of structures must conform to [Hashable](https://developer.apple.com/documentation/swift/hashable) Protocol.
 
 ## Default Property Values
 


### PR DESCRIPTION

### Description

I noticed that on the [site](https://www.codecademy.com/resources/docs/swift/structures) **the link doesn't show up properly** because of the wrong braces. Here is the screenshot of it:
<img width="755" alt="Screenshot 2023-09-02 at 11 22 19" src="https://github.com/Codecademy/docs/assets/126417371/35e1e1cd-189a-4143-ac25-95969b4591ec">

Fixed the braces in this request.

### Type of Change

- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] Under "Development" on the right, I have linked any issues that are relevant to this PR (write "Closes #<issue number> in the "Description" above).