### PR TITLE
fix typos

### DIFF
--- a/content/python/concepts/dictionaries/terms/values/values.md
+++ b/content/python/concepts/dictionaries/terms/values/values.md
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/computer-science'
 ---
 
-The `.values()` method returns all of its values of a Python dictionary in a view object that will refect any changes to the dictionary values. It takes no arguments.
+The `.values()` method returns all of its values of a Python dictionary in a view object that will reflect any changes to the dictionary values. It takes no arguments.
 
 ## Syntax
 

--- a/content/python/concepts/files/terms/write/write.md
+++ b/content/python/concepts/files/terms/write/write.md
@@ -16,7 +16,7 @@ CatalogContent:
 
 The `.write()` file method allows the user to add additional text to a file when the file is opened in append mode.
 
-The position of the additional text is determined by the mode the file was accessed in and the stram position. Append mode will insert the text at the current file handle's reference point. Write mode will first empty the file before inserting the text.
+The position of the additional text is determined by the mode the file was accessed in and the stream position. Append mode will insert the text at the current file handle's reference point. Write mode will first empty the file before inserting the text.
 
 ## Syntax
 

--- a/content/python/concepts/glob-module/terms/escape/escape.md
+++ b/content/python/concepts/glob-module/terms/escape/escape.md
@@ -24,7 +24,7 @@ Any special characters in the `sequence` will be placed in brackets. This includ
 
 ## Codebyte Example
 
-The following example showcases the `.escape()` method and highights each special character:
+The following example showcases the `.escape()` method and highlights each special character:
 
 ```codebyte/python
 import glob


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

This pull request corrects a typo in the file content/javascript/concepts/map/terms/delete/delete.md

### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Editing an existing entry (fixing a typo)

### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] Under "Development" on the right, I have linked any issues that are relevant to this PR (write "Closes #<issue number> in the "Description" above).

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->