### PR TITLE
Fixed syntax in init.md, new.md, repr.md

### DIFF
--- a/content/python/concepts/dunder-methods/terms/init/init.md
+++ b/content/python/concepts/dunder-methods/terms/init/init.md
@@ -22,7 +22,7 @@ The **`__init__()`** method initializes a newly created object. It is called eac
 
 ```pseudo
 class ClassName:
-  __init__(self, param1, param2, ..., paramN):
+  def __init__(self, param1, param2, ..., paramN):
     self.param1 = param1
     self.param2 = param2
     self.paramN = paramN

--- a/content/python/concepts/dunder-methods/terms/new/new.md
+++ b/content/python/concepts/dunder-methods/terms/new/new.md
@@ -22,7 +22,7 @@ The **`__new__()`** static method creates a new instance of a class `cls` and ta
 
 ```pseudo
 class ClassName:
-  __new__(cls, *args, **kwargs):
+  def __new__(cls, *args, **kwargs):
     obj = super().__new__(cls)
     return obj
 ```

--- a/content/python/concepts/dunder-methods/terms/repr/repr.md
+++ b/content/python/concepts/dunder-methods/terms/repr/repr.md
@@ -24,7 +24,7 @@ The **`__repr__()`** dunder method returns the string representation of the obje
 
 ```pseudo
 class ClassName:
-  __repr__(self):
+  def __repr__(self):
 ```
 
 The `__repr__()` method accepts no parameters. `self` is an implicit reference to the instance of `ClassName`.


### PR DESCRIPTION
### Description

Fixed typos in the following files:
- init.md
- new.md
- repr.md

Code examples in these files contained incorrect syntax, declaring methods without using "def".

### Type of Change

- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] Under "Development" on the right, I have linked any issues that are relevant to this PR (write "Closes #<issue number> in the "Description" above).
