### PR TITLE
Typo correction on CSS position right examples

### DIFF
--- a/content/css/concepts/position/terms/right/right.md
+++ b/content/css/concepts/position/terms/right/right.md
@@ -39,7 +39,7 @@ Set the position of `.box` element `40px` off the right edge of the nearest rela
   width: 100px;
   background-color: blue;
   position: absolute;
-  top: 40px;
+  right: 40px;
 }
 ```
 
@@ -53,6 +53,6 @@ Set the position of `.box` element `40px` from the elements right edge.
   width: 100px;
   background-color: blue;
   position: relative;
-  top: 40px;
+  right: 40px;
 }
 ```


### PR DESCRIPTION
### Description

I corrected the examples on CSS>position>right. On both examples it was `top: 40px;` but it should be `right: 40px;` since the examples are for position right.

### Issue Solved

No related issue

### Type of Change

- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.