### PR TITLE
Add membership commands in comands topic

### DIFF
--- a/content/python/concepts/operators/operators.md
+++ b/content/python/concepts/operators/operators.md
@@ -88,4 +88,8 @@ Python evaluates an expression in order of precedence as follows:
 - `and`
 - `or`
 
+## Membership operator
+- The `in` operator returns `True` if the element in the right CONTAINS the element in the left
+- The `not in` operator returns `False` if the element in the right NOT CONTAINS the element in the left
+
 **Note:** Items at the same precedence are evaluated left to right. The exception to this is exponentiation, which evaluates right to left.


### PR DESCRIPTION
Add membership operators at operators topic


### Description

Add an topic that describes the uses of membership operators (`in` and `not in`). The file in question is \docs\content\python\concepts\operators\operators.md

### Issue Solved
Repaired the lack of membership operators in this topic. This membership operators is useful to check if some object contains another one.


### Type of Change

- Adding a new entry
- Updating the documentation

### Checklist

<!-- Please check ALL the boxes: -->

- [ x] All writings are my own.
- [ x] My entry follows the Codecademy Docs style guide.
- [ x] My changes generate no new warnings.
- [ x] I have performed a self-review of my own writing and code.
- [ x] I have checked my entry and corrected any misspellings.
- [ x] I have made corresponding changes to the documentation if needed.
- [ x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

