### PR TITLE
correct "Or" operator from "!!" to "||"

### DIFF
--- a/content/kotlin/concepts/operators/operators.md
+++ b/content/kotlin/concepts/operators/operators.md
@@ -71,7 +71,7 @@ println(d <= b) // false
 Logical operators are used to combine two or more conditions and determine the overall result. Kotlin supports the following logical operators:
 
 - `&&` And: Returns `true` when the argument or expression on either side of the operator are both `true`.
-- `!!` Or: Returns `true` when one of the arguments or expressions in the statement are `true`.
+- `||` Or: Returns `true` when one of the arguments or expressions in the statement are `true`.
 - `!` Not: Returns `true` when the argument or expression is `false`, otherwise `true`.
 
 Here's an example of how to use logical operators in Kotlin:


### PR DESCRIPTION
### Description

Under the "Logical Operators" heading, it shows the "OR" operator as two exclamation points "!!" &mdash; this is not correct. It should be two vertical lines "||"

reported through customer support via this ticket: https://codecademy.atlassian.net/browse/CQ-6994

### Issue Solved

N/A

### Type of Change

- Editing an existing entry: Correction


### Checklist

<!-- Please check ALL the boxes: -->

- [ x ] All writings are my own.
- [ x ] My entry follows the Codecademy Docs style guide.
- [ x ] My changes generate no new warnings.
- [ x ] I have performed a self-review of my own writing and code.
- [ x ] I have checked my entry and corrected any misspellings.
- [ x ] I have made corresponding changes to the documentation if needed.
- [ x ] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ x ] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ x ] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
