### PR TITLE
Fixed inaccurate explanation of the `not in` operator

### DIFF
--- a/content/python/concepts/operators/operators.md
+++ b/content/python/concepts/operators/operators.md
@@ -91,6 +91,6 @@ Python evaluates an expression in order of precedence as follows:
 ## Membership operators
 
 - The `in` operator returns `True` if the element on the left is found within the iterable object on the right. Here, the element on the right side of the `in` operator must be an iterable object like a list, string, dictionary, etc.
-- The `not in` operator returns `False` if the element on the left is not found within the iterable object on the right. Again, the element on the right side of the `not in` operator must be an iterable object.
+- The `not in` operator returns `True` if the element on the left is not found within the iterable object on the right. Again, the element on the right side of the `not in` operator must be an iterable object.
 
 **Note:** Items at the same precedence are evaluated left to right. The exception to this is exponentiation, which evaluates right to left.


### PR DESCRIPTION
Original phrasing was inaccurate and could lead to confusion. The revised explanation clarifies that the `not in` operator returns True when the element isn't found in the iterable and False when it is.

<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

<!-- Please write a summary of the change, such as which topic(s) and file(s) that you have edited or created. Please also include relevant motivation and context: -->

### Issue Solved

<!--
Please use the following format(s) to link the issue numbers that your contribution addresses:
Closes #issue-number (where `issue-number` corresponds to the PRs' respective issue)
-->

Closes #5018 

### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Adding a new entry
- Editing an existing entry (fixing a typo, bug, issues, etc)
- Updating the documentation

### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
