### PR TITLE
[Term Entry] Adding Pytorch Tensor empty

### DIFF
--- a/content/pytorch/concepts/tensors/terms/empty/empty.md
+++ b/content/pytorch/concepts/tensors/terms/empty/empty.md
@@ -26,7 +26,7 @@ The parameters are as follows:
 - `size`: Specifies the shape of the tensor. It can be an integer or a tuple of integers representing the dimensions
 - `out`(Optional): The output Tensor, defaults to `None`.
 - `dtype`(Optional): Specifies the desired data type of the tensor.
-- `layout`(Optional): Specified the layout (`torch.layout`) of the output tensor, defaults to `torch.strided`.
+- `layout`(Optional): Specifies the layout (`torch.layout`) of the output tensor, defaults to `torch.strided`.
 - `device`(Optional): Specifies the device (`torch.device`) of the output tensor, defaults to `None`.
 - `requires_grad`(Optional): A boolean indicating whether autograd will record operations on the output tensor, defaults to `False`.
 - `pin_memory`(Optional): A boolean indicating whether the tensor is allocated in pinned memory. This only works for CPU tensors. Defaults to `False`.

--- a/content/pytorch/concepts/tensors/terms/empty/empty.md
+++ b/content/pytorch/concepts/tensors/terms/empty/empty.md
@@ -1,0 +1,60 @@
+---
+Title: '.empty()'
+Description: 'Creates a new tensor of a specified shape, with uninitialized data.'
+Subjects:
+  - 'AI'
+  - 'Data Science'
+  - 'Machine Learning'
+Tags:
+  - 'AI'
+  - 'Deep Learning'
+CatalogContent:
+  - 'intro-to-py-torch-and-neural-networks'
+  - 'paths/computer-science'
+---
+
+The **`.empty()`** method creates a tensor that has uninitialized data. This means that the tensor is created where there is free data, which may include NaNs or other values. The shape of the tensor must be specified.
+
+## Syntax
+
+```pseudo
+torch.empty(size, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False, pin_memory=False, memory_format=torch.contiguous_format)
+```
+
+The parameters are as follows:
+
+- `size`: The shape of the tensor, specified as a variable, tuple, or list of integers.
+- `out`: The output Tensor, defaults to `None`.
+- `dtype`: The datatype (`torch.dtype`) of the zeros, defaults to `None`.
+- `layout`: The layout (`torch.layout`) of the output tensor, defaults to `torch.strided`.
+- `device`: The device (`torch.device`) of the output tensor, defaults to `None`.
+- `requires_grad`: A boolean indicating whether autograd will record operations on the output tensor, defaults to `False`.
+- `pin_memory`: A boolean indicating whether the tensor is allocated in pinned memory. This only works for CPU tensors. Defaults to `False`.
+- `memory_format`: Memory format (`torch.memory_format`) of the output tensor, defaults to `torch.contiguous_format`.
+
+## Example
+
+```py
+import torch
+
+t0 = torch.empty((1, 3))
+print(t0)
+```
+
+The returned tensor is as follows:
+
+```shell
+tensor([1.245e+11, NaN, -2.956e-52])
+```
+
+## Codebyte Example
+
+Run the following code to see how the `.empty()` method works.
+
+```codebyte/python
+import torch
+
+t0 = torch.empty((4, 2, 3), dtype=torch.int16)
+
+print(t0)
+```

--- a/content/pytorch/concepts/tensors/terms/empty/empty.md
+++ b/content/pytorch/concepts/tensors/terms/empty/empty.md
@@ -24,13 +24,13 @@ torch.empty(size, out=None, dtype=None, layout=torch.strided, device=None, requi
 The parameters are as follows:
 
 - `size`: Specifies the shape of the tensor. It can be an integer or a tuple of integers representing the dimensions
-- `out`: The output Tensor, defaults to `None`.
-- `dtype`: Specifies the desired data type of the tensor.
-- `layout`: Specified the layout (`torch.layout`) of the output tensor, defaults to `torch.strided`.
-- `device`: Specifies the device (`torch.device`) of the output tensor, defaults to `None`.
-- `requires_grad`: A boolean indicating whether autograd will record operations on the output tensor, defaults to `False`.
-- `pin_memory`: A boolean indicating whether the tensor is allocated in pinned memory. This only works for CPU tensors. Defaults to `False`.
-- `memory_format`: Specifies the memory format (`torch.memory_format`) of the output tensor, defaults to `torch.contiguous_format`.
+- `out`(Optional): The output Tensor, defaults to `None`.
+- `dtype`(Optional): Specifies the desired data type of the tensor.
+- `layout`(Optional): Specified the layout (`torch.layout`) of the output tensor, defaults to `torch.strided`.
+- `device`(Optional): Specifies the device (`torch.device`) of the output tensor, defaults to `None`.
+- `requires_grad`(Optional): A boolean indicating whether autograd will record operations on the output tensor, defaults to `False`.
+- `pin_memory`(Optional): A boolean indicating whether the tensor is allocated in pinned memory. This only works for CPU tensors. Defaults to `False`.
+- `memory_format`(Optional): Specifies the memory format (`torch.memory_format`) of the output tensor, defaults to `torch.contiguous_format`.
 
 ## Example
 

--- a/content/pytorch/concepts/tensors/terms/empty/empty.md
+++ b/content/pytorch/concepts/tensors/terms/empty/empty.md
@@ -1,6 +1,6 @@
 ---
 Title: '.empty()'
-Description: 'Creates a new tensor of a specified shape, with uninitialized data.'
+Description: 'Creates a new tensor of a specified shape with uninitialized data.'
 Subjects:
   - 'AI'
   - 'Data Science'
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/computer-science'
 ---
 
-The **`.empty()`** method creates a tensor that has uninitialized data. This means that the tensor is created where there is free data, which may include NaNs or other values. The shape of the tensor must be specified.
+The **`.empty()`** method creates a tensor with uninitialized data. This means that the tensor is allocated memory without setting its values, which may contain arbitrary data (such as NaNs or other undefined values). The shape of the tensor must be specified as an argument.
 
 ## Syntax
 
@@ -23,16 +23,18 @@ torch.empty(size, out=None, dtype=None, layout=torch.strided, device=None, requi
 
 The parameters are as follows:
 
-- `size`: The shape of the tensor, specified as a variable, tuple, or list of integers.
+- `size`: Specifies the shape of the tensor. It can be an integer or a tuple of integers representing the dimensions
 - `out`: The output Tensor, defaults to `None`.
-- `dtype`: The datatype (`torch.dtype`) of the zeros, defaults to `None`.
-- `layout`: The layout (`torch.layout`) of the output tensor, defaults to `torch.strided`.
-- `device`: The device (`torch.device`) of the output tensor, defaults to `None`.
+- `dtype`: Specifies the desired data type of the tensor.
+- `layout`: Specified the layout (`torch.layout`) of the output tensor, defaults to `torch.strided`.
+- `device`: Specifies the device (`torch.device`) of the output tensor, defaults to `None`.
 - `requires_grad`: A boolean indicating whether autograd will record operations on the output tensor, defaults to `False`.
 - `pin_memory`: A boolean indicating whether the tensor is allocated in pinned memory. This only works for CPU tensors. Defaults to `False`.
-- `memory_format`: Memory format (`torch.memory_format`) of the output tensor, defaults to `torch.contiguous_format`.
+- `memory_format`: Specifies the memory format (`torch.memory_format`) of the output tensor, defaults to `torch.contiguous_format`.
 
 ## Example
+
+The example below uses the `.empty()` method:
 
 ```py
 import torch
@@ -49,7 +51,7 @@ tensor([1.245e+11, NaN, -2.956e-52])
 
 ## Codebyte Example
 
-Run the following code to see how the `.empty()` method works.
+Run the following code to see how the `.empty()` method works:
 
 ```codebyte/python
 import torch


### PR DESCRIPTION
Description
Adding new entry on the .arange() term under PyTorch Tensors concept. It is under docs/content/pytorch/concepts/tensors/terms/empty/empty.md

Issue Solved
Addresses issue: https://github.com/Codecademy/docs/issues/5303

Type of Change
Adding a new entry

Checklist
[x ] All writings are my own.
[x ] My entry follows the Codecademy Docs style guide.
[x ] My changes generate no new warnings.
[x ] I have performed a self-review of my own writing and code.
[x ] I have checked my entry and corrected any misspellings.
[x ] I have made corresponding changes to the documentation if needed.
[x ] I have confirmed my changes are not being pushed from my forked main branch.
[x ] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
[x ] I have linked any issues that are relevant to this PR in the Issues Solved section.