### PR TITLE
fixed broken images links

### DIFF
--- a/content/css/concepts/position/terms/left/left.md
+++ b/content/css/concepts/position/terms/left/left.md
@@ -43,7 +43,7 @@ Set the position of `.box` element `40px` off the left edge of the nearest relat
 }
 ```
 
-![Example of position being absolute](<(https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left()-absolute.png)>)
+![Example of position being absolute](https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left%28%29-absolute.png)
 
 ## Example 2
 
@@ -59,4 +59,4 @@ Set the position of `.box` element `40px` from the elements left edge.
 }
 ```
 
-![Example of position being relative](<(https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left()-relative.png)>)
+![Example of position being relative](https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left%28%29-relative.png)


### PR DESCRIPTION
### Description
The URLs for the images contained parentheses, causing the links to break during formatting with yarn format.

Fix: The parentheses in the URLs were replaced with their encoded equivalents, %28 for ( and %29 for ), to ensure the links work correctly during formatting.

**Original:**
```markdown
![Example of position being absolute](https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left()-absolute.png)

![Example of position being relative](https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left()-relative.png)
```

**Encoded:**
```markdown
![Example of position being absolute](https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left%28%29-absolute.png)

![Example of position being relative](https://raw.githubusercontent.com/Codecademy/docs/main/media/example-css-left%28%29-relative.png)
```


### Issue Solved
Closes #5453

### Type of Change
- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist
- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

