### PR TITLE
Check to verify that there are not missing md files

### DIFF
--- a/.github/scripts/validate-content-tree.js
+++ b/.github/scripts/validate-content-tree.js
@@ -1,0 +1,22 @@
+const { readdirSync } = require('node:fs');
+
+let exitCode = 0;
+
+const next = ['concepts', 'terms'];
+
+function checkPath(path, i) {
+  for (const entry of readdirSync(path)) {
+    const entryDir = readdirSync(`${path}/${entry}`);
+    if (!entryDir.includes(`${entry}.md`)) {
+      console.error(`${path}/${entry} should contain a ${entry}.md file`);
+      exitCode = 1;
+    }
+    if (i < 2 && entryDir.includes(next[i])) {
+      checkPath(`${path}/${entry}/${next[i]}`, i + 1);
+    }
+  }
+}
+
+checkPath('content', 0);
+
+process.exit(exitCode);

--- a/.github/scripts/validate-content-tree.js
+++ b/.github/scripts/validate-content-tree.js
@@ -8,7 +8,7 @@ function checkPath(path, i) {
   for (const entry of readdirSync(path)) {
     const entryDir = readdirSync(`${path}/${entry}`);
     if (!entryDir.includes(`${entry}.md`)) {
-      console.error(`${path}/${entry} should contain a ${entry}.md file`);
+      console.error(`\n${path}/${entry} should contain a ${entry}.md file\n`);
       exitCode = 1;
     }
     if (i < 2 && entryDir.includes(next[i])) {

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ["compile", "format:verify", "lint:js", "lint:md", "test"]
+        command: ["compile", "format:verify", "lint:js", "lint:md", "test", "validate-content-tree"]
 
 on:
   push:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lint:md": "markdownlint \"./content/**/*.md\"",
     "lint": "yarn lint:md && yarn lint:js",
     "test": "jest",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "validate-content-tree": "node .github/scripts/validate-content-tree.js"
   },
   "license": "UNLICENSED",
   "version": "1.0.0"


### PR DESCRIPTION
This is meant to prevent "orphaned" docs such as a terms where the parent concept does not have an md file.

Rather than checking for that specifically, we can more generally check to make sure that every folder for a topic/concept/term contains an md file with the same name.

Even after this is merged, it won't be required-for-merge until we add it as a required check in the repo's settings: (`Settings` -> `Branches` -> `main` -> `Edit` -> `Status checks that are required`)