### PR TITLE
[Term Entry]Py torch tensors .view()

### DIFF
--- a/content/pytorch/concepts/nn/terms/loss-functions/loss-functions.md
+++ b/content/pytorch/concepts/nn/terms/loss-functions/loss-functions.md
@@ -1,1 +1,0 @@
-this is test

--- a/content/pytorch/concepts/nn/terms/loss-functions/loss-functions.md
+++ b/content/pytorch/concepts/nn/terms/loss-functions/loss-functions.md
@@ -1,0 +1,1 @@
+this is test

--- a/content/pytorch/concepts/tensors/terms/view/view.md
+++ b/content/pytorch/concepts/tensors/terms/view/view.md
@@ -28,7 +28,7 @@ The function returns a tensor with the specified shape, sharing the same data as
 
 ## Example
 
-This example reshapes a tensor from a shape of *(2, 3)* to *(3, 2)* using `.view()`:
+This example reshapes a tensor from a shape of _(2, 3)_ to _(3, 2)_ using `.view()`:
 
 ```py
 import torch

--- a/content/pytorch/concepts/tensors/terms/view/view.md
+++ b/content/pytorch/concepts/tensors/terms/view/view.md
@@ -1,0 +1,53 @@
+---
+Title: '.view()'
+Description: 'Reshapes a tensor to a specified shape without changing data, ideal for adjusting tensor dimensions to fit model requirements while preserving element count.'
+Subjects:
+  - 'AI'
+  - 'Data Science'
+Tags:
+  - 'AI'
+  - 'Data Types'
+  - 'Deep Learning'
+  - 'Functions'
+CatalogContent:
+  - 'intro-to-py-torch-and-neural-networks'
+  - 'paths/data-science'
+---
+
+The **`.view()`** method in PyTorch reshapes a tensor without changing its data. This is useful for preparing tensors for operations that require specific dimensions, such as feeding data into a neural network. It can change the tensor’s shape, but the total number of elements must remain the same.
+
+## Syntax
+
+```pseudo
+tensor.view(shape)
+```
+
+- `shape`: A tuple or list defining the desired dimensions. The total number of elements must match the original tensor.
+
+The function returns a tensor with the specified shape, sharing the same data as the original tensor.
+
+## Example
+
+This example reshapes a tensor from a shape of `(2, 3)` to `(3, 2)` using `.view()`.
+
+```py
+import torch
+
+# Create a tensor of shape (2, 3)
+original_tensor = torch.tensor([[1, 2, 3], [4, 5, 6]])
+
+# Reshape the tensor to (3, 2)
+reshaped_tensor = original_tensor.view(3, 2)
+
+print(reshaped_tensor)
+```
+
+This example results in the following output:
+
+```shell
+tensor([[1, 2],
+        [3, 4],
+        [5, 6]])
+```
+
+In this example, `.view()` modifies the shape of `original_tensor` while preserving its data.

--- a/content/pytorch/concepts/tensors/terms/view/view.md
+++ b/content/pytorch/concepts/tensors/terms/view/view.md
@@ -1,6 +1,6 @@
 ---
 Title: '.view()'
-Description: 'Reshapes a tensor to a specified shape without changing data, ideal for adjusting tensor dimensions to fit model requirements while preserving element count.'
+Description: 'Reshapes a tensor to a specified shape without changing its data, as long as the total number of elements remains the same.'
 Subjects:
   - 'AI'
   - 'Data Science'
@@ -14,7 +14,7 @@ CatalogContent:
   - 'paths/data-science'
 ---
 
-The **`.view()`** method in PyTorch reshapes a tensor without changing its data. This is useful for preparing tensors for operations that require specific dimensions, such as feeding data into a neural network. It can change the tensor’s shape, but the total number of elements must remain the same.
+The **`.view()`** method in PyTorch reshapes a tensor without altering its underlying data, provided the total number of elements remains the same. This method is useful when preparing tensors for operations requiring specific dimensions, such as neural network inputs.
 
 ## Syntax
 
@@ -28,7 +28,7 @@ The function returns a tensor with the specified shape, sharing the same data as
 
 ## Example
 
-This example reshapes a tensor from a shape of `(2, 3)` to `(3, 2)` using `.view()`.
+This example reshapes a tensor from a shape of *(2, 3)* to *(3, 2)* using `.view()`:
 
 ```py
 import torch


### PR DESCRIPTION
<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

A new term entry about the .view() method for Tensors.

### Issue Solved
#5063

### Type of Change

- Adding a new entry


### Checklist

<!-- Please check ALL the boxes: -->

- [ ✅] All writings are my own.
- [✅ ] My entry follows the Codecademy Docs style guide.
- [ ✅] My changes generate no new warnings.
- [ ✅] I have performed a self-review of my own writing and code.
- [ ✅] I have checked my entry and corrected any misspellings.
- [ ✅] I have made corresponding changes to the documentation if needed.
- [✅ ] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ ✅] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [✅ ] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
