### PR TITLE
feat: [Concept Entry] Git Checkout (#5748)

### DIFF
--- a/content/git/concepts/checkout/checkout.md
+++ b/content/git/concepts/checkout/checkout.md
@@ -1,0 +1,71 @@
+---
+Title: 'Checkout'
+Description: 'The git checkout command switches branches or restores files in the working directory to a specific state.'
+Subjects: 
+  - 'Bash/Shell'
+  - 'Developer Tools'
+Tags:
+  - 'Git'
+  - 'GitHub'
+CatalogContent:
+  - 'learn-the-command-line'
+  - 'learn-git'
+  - 'learn-github-best-practices'
+---
+
+The git **`checkout`** command switches, create and restore branches in the working directory to a specific state. 
+
+It is also possible to checkout to a specific commit without changing branches.
+
+## Syntax
+
+Checkout with branches:
+```pseudo
+git checkout [options] <branch-name>
+```
+Checkout with a specific commit:
+```pseudo
+git checkout <commit-hash>
+```
+## Switch to an existing branch
+
+The following command will switch to an already existing branch, created previously with the [git branch](https://www.codecademy.com/resources/docs/git/branch) command:
+```pseudo
+git checkout existing-branch
+```
+Please, note that from Git 2.23, the new specific `git switch` command has been introduced to switch branches, making it clearer and safer than `git checkout` because it avoids the ambiguity of the latter's multi-purpose nature:
+```pseudo
+git switch existing-branch
+```
+
+## Create and switch to a new branch
+
+It is possible to create and switch to a new branch with a single command, using the `-b` option:
+```pseudo
+git checkout -b new-branch
+```
+or, alternatively, from Git 2.23:
+```pseudo
+git switch -c new-branch
+```
+
+## Restore a file from a specific commit
+
+Restore a file from a specific commit using its hash:
+```pseudo
+git checkout <commit-hash> -- example.txt
+```
+Please, note that from Git 2.23, the new specific `git restore` command has been introduced to restore files from a specific commit:
+```pseudo
+git restore --source <commit-hash> -- example.txt
+```
+
+## Examine a Previous Commit
+Temporarily move to a specific commit without changing branches. This status is called `detached HEAD state`:
+```pseudo
+git checkout <commit-hash>
+```
+The detached HEAD state allow to:
+- Examine the state of the repository at that specified commit.
+- Create new branches if the develop needs to start from that point.
+- Any code changes on this state will not be associated with any existing branch unless one is created.


### PR DESCRIPTION
### Description

<!-- Please write a summary of the change, such as which topic(s) and file(s) that you have edited or created. Please also include relevant motivation and context: -->

Added a new documentation concept entry under `docs/content/git/concepts/checkout/checkout.md` about the **git checkout** command, specifying its behavior and usage with different options. Added also a reference to the new **git switch** (a new Concept should be added in the documentation) and **git restore** introduced from Git 2.23

### Issue Solved

<!--
Please use the following format(s) to link the issue numbers that your contribution addresses:
Closes #issue-number (where `issue-number` corresponds to the PRs' respective issue)
-->

Closes #5748 

### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Adding a new entry

### Checklist

<!-- Please check ALL the boxes: -->

- [X] All writings are my own.
- [X] My entry follows the Codecademy Docs style guide.
- [X] My changes generate no new warnings.
- [X] I have performed a self-review of my own writing and code.
- [X] I have checked my entry and corrected any misspellings.
- [X] I have made corresponding changes to the documentation if needed.
- [X] I have confirmed my changes are not being pushed from my forked `main` branch.
- [X] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [X] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
