### PR TITLE
Lua: comments.md incorrectly shows comment close as ]]--

### DIFF
--- a/content/lua/concepts/comments/comments.md
+++ b/content/lua/concepts/comments/comments.md
@@ -29,11 +29,11 @@ The comment does not affect the function.
 
 ## Multi-line Comments
 
-In Lua, multi-line comments are created using the `--[[` syntax to start the comment, and `]]--` to end the comment. The compiler does not read any text in between.
+In Lua, multi-line comments are created using the `--[[` syntax to start the comment, and `]]` to end the comment. The compiler does not read any text in between.
 
 ```lua
 --[[ this is a multi-line comment.
  The compiler
  will not run code
- written in between. ]]--
+ written in between. ]]
 ```


### PR DESCRIPTION
### Description

This is wrong, as in the case
```lua
print(--[[ I am a comment ]]-- 123)
```
The way to close a multiline comment is to close the string with `]]

```lua
print(--[[ I am a comment ]] 123)
```

### Issue Solved

No issue number

### Type of Change

- Editing an existing entry (fixing a typo)


### Checklist


- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ ] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ ] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
