### PR TITLE
Contributed .from_numpy() Reference in PyTorch Docs

### DIFF
--- a/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
+++ b/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/computer-science'
 ---
 
-The **`.from_numpy()`** function in PyTorch creates a tensor from a NumPy array. The returned tensor shares the same memory as the original NumPy array, so changes made to one will affect the other.
+The **`.from_numpy()`** function in PyTorch creates a tensor from a NumPy array, sharing memory with it, so changes in one affect the other.
 
 ## Syntax
 
@@ -21,27 +21,26 @@ The **`.from_numpy()`** function in PyTorch creates a tensor from a NumPy array.
 torch.from_numpy(ndarray)
 ```
 
-- `memory sharing`: The tensor shares the same memory with the NumPy array, so they are not copies. This is efficient in memory, but changes to one will affect the other.
-- `dtype`: The tensor will have the same `dtype` as the NumPy array. For example, if the array is `float64`, the tensor will be `torch.float64`.
-- `device`: The tensor is created on the CPU, as NumPy arrays are on the CPU. To move the tensor to a GPU or other device, use the `.to()` method after conversion.
-- `requires_grad`: The default value is `False`. To create a tensor that tracks gradients, set `requires_grad=True`.
+- `ndarray`: A NumPy array to be converted into a PyTorch tensor. It must be a NumPy array with a supported dtype (e.g., `float32`, `int64`).
 
 ## Example
 
 The following example uses the `.from_numpy()` function to convert a NumPy array into a PyTorch tensor:
-```
+
+```py
 import numpy as np
 import torch
 
+# Create a NumPy array
 np_array = np.array([1, 2, 3, 4])
 
+# Convert NumPy array to a PyTorch tensor (shared memory)
 tensor = torch.from_numpy(np_array)
-
 print(tensor)
 ```
-```
+
 The output is:
-```
-```
+
+```shell
 tensor([1, 2, 3, 4])
 ```

--- a/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
+++ b/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
@@ -13,11 +13,11 @@ CatalogContent:
   - 'paths/computer-science'
 ---
 
-The **`.from_numpy()`** function in PyTorch creates a [tensor](https://www.codecademy.com/resources/docs/pytorch/tensors) from a NumPy array, sharing memory with it, so changes in one affect the other.
+The **`.from_numpy()`** function in PyTorch creates a [tensor](https://www.codecademy.com/resources/docs/pytorch/tensors) from a NumPy array, sharing the underlying memory. Changes to the NumPy array will affect the tensor. However, only in-place operations on the tensor will affect the NumPy array, while operations that create new tensors will not.
 
 ## Syntax
 
-```python
+```pseudo
 torch.from_numpy(ndarray)
 ```
 

--- a/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
+++ b/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/computer-science'
 ---
 
-The **`.from_numpy()`** function in PyTorch creates a tensor from a NumPy array, sharing memory with it, so changes in one affect the other.
+The **`.from_numpy()`** function in PyTorch creates a [tensor](https://www.codecademy.com/resources/docs/pytorch/tensors) from a NumPy array, sharing memory with it, so changes in one affect the other.
 
 ## Syntax
 

--- a/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
+++ b/content/pytorch/concepts/tensor-operations/terms/from-numpy/from-numpy.md
@@ -1,0 +1,47 @@
+---
+Title: '.from_numpy()'
+Description: 'Converts a NumPy array into a PyTorch tensor, sharing memory between both and changes to one affect the other.'
+Subjects:
+  - 'Data Science'
+  - 'Machine Learning'
+Tags:
+  - 'NumPy'
+  - 'PyTorch'
+  - 'Tensor'
+CatalogContent:
+  - 'intro-to-py-torch-and-neural-networks'
+  - 'paths/computer-science'
+---
+
+The **`.from_numpy()`** function in PyTorch creates a tensor from a NumPy array. The returned tensor shares the same memory as the original NumPy array, so changes made to one will affect the other.
+
+## Syntax
+
+```python
+torch.from_numpy(ndarray)
+```
+
+- `memory sharing`: The tensor shares the same memory with the NumPy array, so they are not copies. This is efficient in memory, but changes to one will affect the other.
+- `dtype`: The tensor will have the same `dtype` as the NumPy array. For example, if the array is `float64`, the tensor will be `torch.float64`.
+- `device`: The tensor is created on the CPU, as NumPy arrays are on the CPU. To move the tensor to a GPU or other device, use the `.to()` method after conversion.
+- `requires_grad`: The default value is `False`. To create a tensor that tracks gradients, set `requires_grad=True`.
+
+## Example
+
+The following example uses the `.from_numpy()` function to convert a NumPy array into a PyTorch tensor:
+```
+import numpy as np
+import torch
+
+np_array = np.array([1, 2, 3, 4])
+
+tensor = torch.from_numpy(np_array)
+
+print(tensor)
+```
+```
+The output is:
+```
+```
+tensor([1, 2, 3, 4])
+```


### PR DESCRIPTION
### Description

Added a .from_numpy() function reference in PyTorch docs, covering its usage, syntax, and memory-sharing behavior between NumPy arrays and tensors. The update makes PyTorch documentation clear and complete.

### Issue Solved

Closes #6099

### Type of Change

Adding a new entry

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.
