### PR TITLE
[Term Entry] PyTorch Tensor Operations: `.as_strided()`

### DIFF
--- a/content/pytorch/concepts/tensor-operations/terms/as-strided/as-strided.md
+++ b/content/pytorch/concepts/tensor-operations/terms/as-strided/as-strided.md
@@ -8,6 +8,7 @@ Tags:
   - 'AI'
   - 'Data Types'
   - 'Deep Learning'
+  - 'Functions'
 CatalogContent:
   - 'intro-to-py-torch-and-neural-networks'
   - 'paths/data-science'
@@ -41,6 +42,7 @@ tensor = torch.arange(10)
 # Create a 2x3 strided view (overlapping windows)
 windowed_tensor = tensor.as_strided((2, 3), (2, 1))
 
+# Print the resultant tensor
 print(windowed_tensor)
 ```
 
@@ -53,6 +55,6 @@ tensor([[0, 1, 2],
 
 - The original tensor `tensor` contains values `[0, 1, 2, ..., 9]`.
 - The `.as_strided()` function generates a view where:
-  - The new shape is `(2,3)`, meaning two rows and three columns.
+  - The new shape is `(2, 3)`, meaning two rows and three columns.
   - The first stride is `2`, meaning each row starts 2 elements ahead in the original tensor.
   - The second stride is `1`, meaning elements within each row are consecutive.

--- a/content/pytorch/concepts/tensor-operations/terms/as-strided/as-strided.md
+++ b/content/pytorch/concepts/tensor-operations/terms/as-strided/as-strided.md
@@ -1,0 +1,58 @@
+---
+Title: '.as_strided()'
+Description: 'Creates a view of a tensor with a specified shape and strides.'
+Subjects:
+  - 'AI'
+  - 'Data Science'
+Tags:
+  - 'AI'
+  - 'Data Types'
+  - 'Deep Learning'
+CatalogContent:
+  - 'intro-to-py-torch-and-neural-networks'
+  - 'paths/data-science'
+---
+
+In PyTorch, the **`.as_strided()`** function creates a view of a tensor with a specified shape and strides. Unlike operations that copy data, `.as_strided()` allows modifying how the tensor accesses memory, which enables efficient slicing, reshaping, and advanced indexing without additional memory allocation.
+
+> **Note:** Since `.as_strided()` manipulates tensor memory layout directly, incorrect stride values can lead to unexpected behavior or memory overlap.
+
+## Syntax
+
+```pseudo
+torch.as_strided(input, size, stride, storage_offset=None)
+```
+
+- `input`: The input tensor.
+- `size`: The desired shape of the output tensor.
+- `stride`: A tuple specifying the step size to move across dimensions.
+- `storage_offset` (Optional): Defines the starting point in the underlying storage for the output tensor. If set to `None`, the output tensor retains the same `storage_offset` as the input tensor.
+
+## Example
+
+The following example demonstrates how `.as_strided()` can be used to create a sliding window view of a tensor:
+
+```py
+import torch
+
+# Create a 1D tensor
+tensor = torch.arange(10)
+
+# Create a 2x3 strided view (overlapping windows)
+windowed_tensor = tensor.as_strided((2, 3), (2, 1))
+
+print(windowed_tensor)
+```
+
+This code generates the output as:
+
+```shell
+tensor([[0, 1, 2],
+        [2, 3, 4]])
+```
+
+- The original tensor `tensor` contains values `[0, 1, 2, ..., 9]`.
+- The `.as_strided()` function generates a view where:
+  - The new shape is `(2,3)`, meaning two rows and three columns.
+  - The first stride is `2`, meaning each row starts 2 elements ahead in the original tensor.
+  - The second stride is `1`, meaning elements within each row are consecutive.


### PR DESCRIPTION
<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description
Added a Term Entry for PyTorch Tensor Operations: `.as_strided()`


### Issue Solved
Closes #6098 

### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Adding a new entry

### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [ ] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
