### PR TITLE
Fix typo in position property list (removed extra 'or')

### DIFF
--- a/content/css/concepts/position/position.md
+++ b/content/css/concepts/position/position.md
@@ -15,4 +15,4 @@ CatalogContent:
 
 Positioning in CSS provides designers and developers options for positioning HTML elements on a web page.
 
-The CSS position can be set to `static`, `relative`, `absolute`, or `fixed` or `sticky`.
+The CSS position can be set to `static`, `relative`, `absolute`, `fixed` or `sticky`.


### PR DESCRIPTION
### Description

Fixed a typo in the CSS `position` property description in `position.md`. Removed the repeated "or".

### Issue Solved

no issues

### Type of Change

- Editing an existing entry (fixing a typo)

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.