### PR TITLE
.get() method information added as markdown file

### DIFF
--- a/content/cpp/concepts/pointers/terms/get/get.md
+++ b/content/cpp/concepts/pointers/terms/get/get.md
@@ -1,28 +1,38 @@
-# `.get()` method under Pointers in C++
+---
+Title: '.get()'
+Description: 'Retrieves the raw pointer managed by a smart pointer without releasing ownership.'
+Subjects:
+  - 'Code Foundations'
+  - 'Computer Science'
+Tags:
+  - 'Memory'
+  - 'Pointers'
+  - 'Programming'
+  - 'Variables'
+CatalogContent:
+  - 'learn-c-plus-plus'
+  - 'paths/computer-science'
+---
 
 The **`.get()`** member function is used with smart pointers in C++, namely `std::unique_ptr` and `std::shared_ptr`. It returns the raw pointer managed by the smart pointer without relinquishing ownership. This allows direct access to the managed object when needed, especially for interoperability with legacy or third-party code that expects traditional pointers.
 
 ## Syntax
 
-### For `std::unique_ptr`:
-
-```cpp
-T* get() const noexcept;
+```pseudo
+smart_pointer.get();
 ```
 
-- Returns the stored pointer.
-- Does not release ownership.
+**Parameters:**
 
-### For `std::shared_ptr`:
+The `.get()` function does not take any parameters.
 
-```cpp
-T* get() const noexcept;
-```
+**Return value:**
 
-- Returns the stored pointer.
-- Does not change the reference count or ownership.
+Returns the raw pointer managed by the smart pointer (e.g., `std::unique_ptr` or `std::shared_ptr`), allowing read-only or non-owning access to the resource.
 
 ## Example 1: Using `.get()` with `std::unique_ptr`
+
+In this example, `.get()` is used to access the raw pointer managed by a `unique_ptr` to read the stored value:
 
 ```cpp
 #include <iostream>
@@ -36,7 +46,15 @@ int main() {
 }
 ```
 
+The output of this code is:
+
+```shell
+Value: 42
+```
+
 ## Example 2: Using `.get()` with `std::shared_ptr`
+
+In this example, `.get()` retrieves the raw pointer from a `shared_ptr` to access the value it manages:
 
 ```cpp
 #include <iostream>
@@ -50,7 +68,13 @@ int main() {
 }
 ```
 
-## Codebyte
+The output of this code is:
+
+```shell
+Value: 99
+```
+
+## Codebyte Example
 
 ```codebyte/cpp
 #include <iostream>
@@ -70,10 +94,3 @@ int main() {
   return 0;
 }
 ```
-
-## Notes
-
-- `.get()` gives access to the raw pointer without transferring or modifying ownership.
-- The smart pointer still controls the resource's lifetime.
-- Avoid passing the raw pointer to code that might delete or store it, as this can lead to undefined behavior.
-- Always make sure the smart pointer outlives the use of the raw pointer.

--- a/content/cpp/concepts/pointers/terms/nullptr/get/get.md
+++ b/content/cpp/concepts/pointers/terms/nullptr/get/get.md
@@ -43,10 +43,10 @@ int main() {
 #include <memory>
 
 int main() {
-    std::shared_ptr<int> ptr = std::make_shared<int>(99);
-    int* rawPtr = ptr.get();
-    std::cout << "Value: " << *rawPtr << std::endl;
-    return 0;
+  std::shared_ptr<int> ptr = std::make_shared<int>(99);
+  int* rawPtr = ptr.get();
+  std::cout << "Value: " << *rawPtr << std::endl;
+  return 0;
 }
 ```
 

--- a/content/cpp/concepts/pointers/terms/nullptr/get/get.md
+++ b/content/cpp/concepts/pointers/terms/nullptr/get/get.md
@@ -22,9 +22,7 @@ T* get() const noexcept;
 - Returns the stored pointer.
 - Does not change the reference count or ownership.
 
-## Example
-
-### Using `.get()` with `std::unique_ptr`
+## Example 1: Using `.get()` with `std::unique_ptr`
 
 ```cpp
 #include <iostream>

--- a/content/cpp/concepts/pointers/terms/nullptr/get/get.md
+++ b/content/cpp/concepts/pointers/terms/nullptr/get/get.md
@@ -1,0 +1,81 @@
+# `.get()` method under Pointers in C++
+
+The `.get()` member function is used with smart pointers in C++—namely `std::unique_ptr` and `std::shared_ptr`. It returns the raw pointer managed by the smart pointer without relinquishing ownership. This allows direct access to the managed object when needed, especially for interoperability with legacy or third-party code that expects traditional pointers.
+
+## Syntax
+
+### For `std::unique_ptr`:
+
+```cpp
+T* get() const noexcept;
+```
+
+- Returns the stored pointer.
+- Does not release ownership.
+
+### For `std::shared_ptr`:
+
+```cpp
+T* get() const noexcept;
+```
+
+- Returns the stored pointer.
+- Does not change the reference count or ownership.
+
+## Example
+
+### Using `.get()` with `std::unique_ptr`
+
+```cpp
+#include <iostream>
+#include <memory>
+
+int main() {
+    std::unique_ptr<int> ptr = std::make_unique<int>(42);
+    int* rawPtr = ptr.get();
+    std::cout << "Value: " << *rawPtr << std::endl;
+    return 0;
+}
+```
+
+### Using `.get()` with `std::shared_ptr`
+
+```cpp
+#include <iostream>
+#include <memory>
+
+int main() {
+    std::shared_ptr<int> ptr = std::make_shared<int>(99);
+    int* rawPtr = ptr.get();
+    std::cout << "Value: " << *rawPtr << std::endl;
+    return 0;
+}
+```
+
+## Codebyte
+
+```codebyte/cpp
+#include <iostream>
+#include <memory>
+
+void printRawPointer(int* ptr) {
+    std::cout << "Inside function: " << *ptr << std::endl;
+}
+
+int main() {
+    std::unique_ptr<int> uniquePtr = std::make_unique<int>(100);
+    int* raw = uniquePtr.get();
+
+    printRawPointer(raw);
+    std::cout << "Back in main: " << *raw << std::endl;
+
+    return 0;
+}
+```
+
+## Notes
+
+- `.get()` gives access to the raw pointer without transferring or modifying ownership.
+- The smart pointer still controls the resource's lifetime.
+- Avoid passing the raw pointer to code that might delete or store it, as this can lead to undefined behavior.
+- Always make sure the smart pointer outlives the use of the raw pointer.

--- a/content/cpp/concepts/pointers/terms/nullptr/get/get.md
+++ b/content/cpp/concepts/pointers/terms/nullptr/get/get.md
@@ -57,17 +57,17 @@ int main() {
 #include <memory>
 
 void printRawPointer(int* ptr) {
-    std::cout << "Inside function: " << *ptr << std::endl;
+  std::cout << "Inside function: " << *ptr << std::endl;
 }
 
 int main() {
-    std::unique_ptr<int> uniquePtr = std::make_unique<int>(100);
-    int* raw = uniquePtr.get();
+  std::unique_ptr<int> uniquePtr = std::make_unique<int>(100);
+  int* raw = uniquePtr.get();
 
-    printRawPointer(raw);
-    std::cout << "Back in main: " << *raw << std::endl;
+  printRawPointer(raw);
+  std::cout << "Back in main: " << *raw << std::endl;
 
-    return 0;
+  return 0;
 }
 ```
 

--- a/content/cpp/concepts/pointers/terms/nullptr/get/get.md
+++ b/content/cpp/concepts/pointers/terms/nullptr/get/get.md
@@ -36,7 +36,7 @@ int main() {
 }
 ```
 
-### Using `.get()` with `std::shared_ptr`
+## Example 2: Using `.get()` with `std::shared_ptr`
 
 ```cpp
 #include <iostream>

--- a/content/cpp/concepts/pointers/terms/nullptr/get/get.md
+++ b/content/cpp/concepts/pointers/terms/nullptr/get/get.md
@@ -1,6 +1,6 @@
 # `.get()` method under Pointers in C++
 
-The `.get()` member function is used with smart pointers in C++—namely `std::unique_ptr` and `std::shared_ptr`. It returns the raw pointer managed by the smart pointer without relinquishing ownership. This allows direct access to the managed object when needed, especially for interoperability with legacy or third-party code that expects traditional pointers.
+The **`.get()`** member function is used with smart pointers in C++, namely `std::unique_ptr` and `std::shared_ptr`. It returns the raw pointer managed by the smart pointer without relinquishing ownership. This allows direct access to the managed object when needed, especially for interoperability with legacy or third-party code that expects traditional pointers.
 
 ## Syntax
 

--- a/content/cpp/concepts/pointers/terms/nullptr/get/get.md
+++ b/content/cpp/concepts/pointers/terms/nullptr/get/get.md
@@ -29,10 +29,10 @@ T* get() const noexcept;
 #include <memory>
 
 int main() {
-    std::unique_ptr<int> ptr = std::make_unique<int>(42);
-    int* rawPtr = ptr.get();
-    std::cout << "Value: " << *rawPtr << std::endl;
-    return 0;
+  std::unique_ptr<int> ptr = std::make_unique<int>(42);
+  int* rawPtr = ptr.get();
+  std::cout << "Value: " << *rawPtr << std::endl;
+  return 0;
 }
 ```
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

Created a new Markdown documentation entry for the .get() method under the topic of smart pointers in C++. 

### Issue Solved

Closes #6871 

### Type of Change

- Adding a new entry

### Checklist

<!-- Please check ALL the boxes: -->

- [X] All writings are my own.
- [X] My entry follows the Codecademy Docs style guide.
- [X] My changes generate no new warnings.
- [X] I have performed a self-review of my own writing and code.
- [ ] I have checked my entry and corrected any misspellings.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ ] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ ] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
