### PR TITLE
 Add fromCodePoint() entry under javascript strings

### DIFF
--- a/content/javascript/concepts/strings/terms/fromCodePoint/fromCodePoint.md
+++ b/content/javascript/concepts/strings/terms/fromCodePoint/fromCodePoint.md
@@ -1,0 +1,15 @@
+# fromCodePoint()
+
+`String.fromCodePoint()` is a static method in JavaScript that returns a string created from the specified sequence of code points.
+
+## Syntax
+
+```javascript
+String.fromCodePoint(num1[, ...numN])
+
+console.log(String.fromCodePoint(9731, 9733, 9842, 0x2F804));
+// Output: ☃★♲你
+
+const snowman = String.fromCodePoint(9731);
+console.log(snowman); // ☃
+


### PR DESCRIPTION
This PR adds a new documentation entry for `String.fromCodePoint()` under JavaScript Strings. It includes:
- A description of the method
- Syntax explanation
- Example usage
- A runnable Codebyte block
