### PR TITLE
[Entry] C++ unordered map: max_load_factor()

### DIFF
--- a/content/cpp/concepts/unordered-map/terms/max_load-factor/max_load-factor.md
+++ b/content/cpp/concepts/unordered-map/terms/max_load-factor/max_load-factor.md
@@ -1,0 +1,112 @@
+---
+Title: 'max_load_factor()'
+Description: 'Gets or sets the maximum average number of elements per bucket before rehashing occurs in an unordered_map.'
+Subjects:
+  - 'Computer Science'
+  - 'Data Science'
+Tags:
+  - 'Map'
+  - 'STL'
+CatalogContent:
+  - 'learn-c-plus-plus'
+  - 'paths/computer-science'
+---
+
+The **`unordered_map::max_load_factor`** function in C++ is used to get or set the maximum load factor of an `unordered_map`. The load factor represents the average number of elements per bucket (i.e., total elements divided by total buckets). By default, this value is set to `1.0`.
+
+## Syntax
+
+```cpp
+unordered_mapName.max_load_factor();        // Getter
+unordered_mapName.max_load_factor(value);   // Setter
+```
+
+**Parameters:**
+
+- `value` (optional): A `float` specifying the new maximum load factor. Must be greater than 0.
+
+**Return value:**
+
+Returns the current maximum load factor as a `float`.
+
+## Example 1: Getting the default load factor
+
+This example prints the default max load factor of an unordered map:
+
+```cpp
+#include <iostream>
+#include <unordered_map>
+
+int main() {
+  std::unordered_map<int, int> myMap;
+  std::cout << "Default max load factor: " << myMap.max_load_factor() << std::endl;
+  return 0;
+}
+```
+
+The output of this code is:
+
+```shell
+Default max load factor: 1
+```
+
+This shows that the default load factor is typically `1.0`, meaning the map aims for one element per bucket.
+
+## Example 2: Setting a custom load factor to reduce rehashing
+
+This example increases the max load factor to reduce the frequency of rehashing during insertions:
+
+```cpp
+#include <iostream>
+#include <unordered_map>
+
+int main() {
+  std::unordered_map<int, int> data;
+  data.max_load_factor(2.5);
+
+  std::cout << "New max load factor: " << data.max_load_factor() << std::endl;
+  return 0;
+}
+```
+
+The output of this code is:
+
+```shell
+New max load factor: 2.5
+```
+
+Raising the load factor allows more elements per bucket, delaying rehashing and potentially improving insertion performance.
+
+## Codebyte Example: Lowering load factor to improve search speed
+
+This example sets a lower load factor to prioritize faster lookups in a time-critical application:
+
+```codebye/cpp
+#include <iostream>
+#include <unordered_map>
+
+int main() {
+  std::unordered_map<std::string, int> wordCount;
+  wordCount.max_load_factor(0.5);
+
+  wordCount["optimize"] = 1;
+  wordCount["speed"] = 2;
+
+  std::cout << "Load factor set for quick access: " << wordCount.max_load_factor() << std::endl;
+  return 0;
+}
+```
+
+## Frequently asked questions
+
+### 1. What is the default `max_load_factor` for an unordered_map?
+
+It's usually `1.0`, meaning one element per bucket on average before rehashing is triggered.
+
+### 2. Does increasing the load factor make the map faster?
+
+It can speed up insertions by reducing rehashes, but may slow down lookups due to more collisions.
+
+### 3. What happens if I set the load factor too low?
+
+The map will rehash more often, using more memory and slowing down insertions, but lookups may become faster.


### PR DESCRIPTION
<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

[Entry] C++ unordered map: max_load_factor()

### Issue Solved

Closes #7142 
### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Adding a new entry


### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [ ] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
