### PR TITLE
[Term Entry] PyTorch Tensor Operations: .fmod()

### DIFF
--- a/content/pytorch/concepts/tensor-operations/terms/fmod/fmod.md
+++ b/content/pytorch/concepts/tensor-operations/terms/fmod/fmod.md
@@ -1,0 +1,81 @@
+---
+Title: '.fmod()' 
+Description: 'Computes element-wise remainder of tensor division with sign matching the dividend.'
+Subjects: 
+  - 'Computer Science'
+  - 'Machine Learning'
+Tags: 
+  - 'Functions'
+  - 'Machine Learning'
+  - 'Python'
+  - 'Tensor'
+CatalogContent: 
+  - 'intro-to-py-torch-and-neural-networks'
+  - 'paths/computer-science'
+---
+
+In PyTorch, the .fmod() method performs element-wise modulo operation on a tensor [tensor](https://www.codecademy.com/resources/docs/pytorch/tensors) and returns a new tensor containing the remainders. The sign of the result always matches the sign of the dividend (the input tensor elements).
+
+Mathematically, for each element in the input tensor, the operation follows:
+
+$$
+\text{result} = \text{input} - (\text{divisor} \times \text{trunc}(\text{input}/\text{divisor}))
+$$
+
+where `trunc` means truncation toward zero (i.e., rounding towards 0).  
+
+## Syntax
+
+
+
+### 1. Tensor Method Call
+```python
+result = tensor.fmod(divisor)
+```
+
+### 2. Function Form Call
+```python
+result = torch.fmod(input, divisor)
+
+```
+
+### 3. In-place Operation
+```python
+tensor.fmod_(divisor)  # Modifies original tensor, returns no new tensor
+```
+
+**Parameters**
+
+- **`input`** (Tensor): The dividend tensor
+- **`divisor`** (Tensor or Number): The divisor, can be:
+  - Scalar value (int or float)
+  - Tensor with the same shape as input
+  - Tensor broadcastable to input's shape
+
+**Return Value**
+- Returns a new tensor containing element-wise remainder results
+- Result tensor has the same shape as input tensor (considering broadcast rules)
+
+
+
+## Example
+
+```python
+import torch
+
+# Scalar divisor
+x = torch.tensor([5.0, -3.5, 2.1])
+result = x.fmod(2)  # or torch.fmod(x, 2)
+print(result)  # tensor([1.0000, -1.5000, 0.1000])
+
+# Tensor divisor
+x = torch.tensor([5.0, -3.5, 2.1])
+y = torch.tensor([3.0, 2.0, 1.5])
+result = x.fmod(y)
+print(result)  # tensor([2.0000, -1.5000, 0.6000])
+
+# In-place operation
+x = torch.tensor([5.0, -3.5, 2.1])
+x.fmod_(2)  # x is modified directly
+print(x)  # tensor([1.0000, -1.5000, 0.1000])
+```


### PR DESCRIPTION
<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

<!-- Please write a summary of the change, such as which topic(s) and file(s) that you have edited or created. Please also include relevant motivation and context: -->

This PR adds a new documentation entry for PyTorch's `.fmod()` method, following the structure of existing terms (e.g., `.frexp()`). The entry includes:  
- A clear explanation of the element-wise modulo operation, where the result’s sign matches the dividend.  
- Syntax examples for **3 usage patterns**:  
  - Tensor method: `tensor.fmod(divisor)`  
  - Functional form: `torch.fmod(input, divisor)`  
  - In-place operation: `tensor.fmod_(divisor)`  
- Code examples demonstrating:  
  - Scalar divisors (e.g., `x.fmod(2)`).  
  - Tensor divisors (e.g., `x.fmod(y)` with matching shapes).  
  - In-place modification (e.g., `x.fmod_(2)`).  
- Mathematical formula and sign behavior details to align with PyTorch’s implementation. 

### Issue Solved

<!--
Please use the following format(s) to link the issue numbers that your contribution addresses:
Closes #issue-number (where `issue-number` corresponds to the PRs' respective issue)
-->
Closes #7501


### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Adding a new entry

### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
