### PR TITLE
Fix equality operator in getInput1 function example

### DIFF
--- a/content/c-sharp/concepts/conditionals/conditionals.md
+++ b/content/c-sharp/concepts/conditionals/conditionals.md
@@ -127,7 +127,7 @@ Is this condition true ? Run this if yes : Run this if no;
 In the example below, the condition that is checked is if `input1` is equal to 10. If that condition is true, it returns the first string. Otherwise, it returns the second string:
 
 ```cs
-string getInput1(int input1) => input1 === 10 ? "I returned true" : "I returned false";
+string getInput1(int input1) => input1 == 10 ? "I returned true" : "I returned false";
 
 Console.WriteLine(getInput1(10)); // Output: "I returned true"
 Console.WriteLine(getInput1(5)); // Output: "I returned false"


### PR DESCRIPTION
### Description
Fixed equality operator in conditionals.md. Changed getInput1 function example from === to ==  as there is no === operator in C#


### Type of Change
- Editing an existing entry (fixing a typo, bug, issues, etc)
- Updating the documentation

### Checklist
- [ y] All writings are my own.
- [ y] My entry follows the Codecademy Docs style guide.
- [ y] My changes generate no new warnings.
- [ y] I have performed a self-review of my own writing and code.
- [ y] I have checked my entry and corrected any misspellings.
- [ y] I have made corresponding changes to the documentation if needed.
- [ y] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ y] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ y] I have linked any issues that are relevant to this PR in the `Issues Solved` section.