### PR TITLE
Add URL() term entry documentation #7462

### DIFF
--- a/content/css/concepts/filter-functions/terms/url/url.md
+++ b/content/css/concepts/filter-functions/terms/url/url.md
@@ -43,7 +43,7 @@ Set the background image of the .banner-image class to cat.png:
 
 ```css
 .banner-image {
-  background-image: url("../images/cat.png");
+  background-image: url('../images/cat.png');
 }
 ```
 
@@ -66,13 +66,12 @@ Load a custom font called `customFont` with multiple formats for compatibility:
 
 ```css
 @font-face {
-  font-family: "customFont";
-  src: url("fonts/customFont.woff2") format("woff2"),
-       url("fonts/customFont.woff") format("woff"),
-       url("fonts/customFont.ttf") format("truetype");
+  font-family: 'customFont';
+  src: url('fonts/customFont.woff2') format('woff2'), url('fonts/customFont.woff')
+      format('woff'), url('fonts/customFont.ttf') format('truetype');
 }
 
 h1 {
-    font-family: "customFont", serif;
+  font-family: 'customFont', serif;
 }
 ```

--- a/content/css/concepts/filter-functions/terms/url/url.md
+++ b/content/css/concepts/filter-functions/terms/url/url.md
@@ -1,0 +1,78 @@
+---
+Title: 'url()'
+Description: 'References an external resource such as an image, icon, or other asset provided by the file path or URL.'
+Subjects:
+  - 'Web Development'
+  - 'Web Design'
+Tags:
+  - 'World Wide Web'
+  - 'Files'
+  - 'CSS'
+  - 'Url'
+  - 'Images'
+CatalogContent:
+  - 'learn-css'
+  - 'paths/front-end-engineer-career-path'
+  - 'paths/full-stack-engineer-career-path'
+---
+
+A CSS function that accepts a file path or URL as its parameter and references an external resource-such as an image, font, icon, or other asset-for use in a stylesheet.
+
+## Syntax
+
+```css
+/* Common form */
+property: url(<path-to-file>);
+
+/* With modifiers */
+property: url(<path-to-file> <url-modifier>*);
+```
+
+Here the required `<path-to-file>` can be one of the following:
+
+- Relative path: `url("images/cat.png")`
+- Absolute path: `url("https://www.google.com/images/cat.png")`
+- Data URI: `url("data:image/png;base64,...")`
+- Blob URL: `url("blob:https://google.com/1234-5678")`
+
+**Note:** Due to Cross-Origin-Resources (CORS), resources hosted on another domain will need permission to render to prevent malicious code from executing.
+
+## Example 1
+
+Set the background image of the .banner-image class to cat.png:
+
+```css
+.banner-image {
+  background-image: url("../images/cat.png");
+}
+```
+
+**Note:** Relative paths are resolved from the CSS file's location, not the HTML file.
+
+Though rarely used, the optional `<url-modifier>*` provides additional information about the resource (path provided) to the browser. This piece of code informs what resource type the path is, increases performance optimization by handling how and if the file will be downloaded, and clarifies the correct file extension. The `*` at the end represents that there can be zero, one, or more then one modifier added. The modifier argument is used in `@font-face` majority of the time with the `format()` modifier.
+
+Here `<url-modifier>*` can be one of the following:
+
+- WOFF2 format: `url("fonts/MyFont.woff2") format("woff2")`
+- WOFF format: `url("fonts/MyFont.woff") format("woff")`
+- TrueType format: `url("fonts/MyFont.ttf") format("truetype")`
+- OpenType format: `url("fonts/MyFont.otf") format("opentype")`
+- Embedded OpenType (legacy IE): `url("fonts/MyFont.eot") format("embedded-opentype")`
+- SVG fonts (legacy): `url("fonts/MyFont.svg") format("svg")`
+
+## Example 2
+
+Load a custom font called `customFont` with multiple formats for compatibility:
+
+```css
+@font-face {
+  font-family: "customFont";
+  src: url("fonts/customFont.woff2") format("woff2"),
+       url("fonts/customFont.woff") format("woff"),
+       url("fonts/customFont.ttf") format("truetype");
+}
+
+h1 {
+    font-family: "customFont", serif;
+}
+```


### PR DESCRIPTION

### Description

Created documentation for the url() function for CSS. File location is /docs/content/css/concepts/filter-functions/terms/url/url.md.


### Issue Solved

Resolved issue number #7462.

### Type of Change

- Adding a new entry

### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

All tests passed from yarn test, yarn lint, and yarn format:all.
