### PR TITLE
Add documentation for deque push_front method

### DIFF
--- a/content/cpp/concepts/deque/terms/push-front/push-front.md
+++ b/content/cpp/concepts/deque/terms/push-front/push-front.md
@@ -1,0 +1,79 @@
+---
+Title: '.push_front()'
+Description: 'Adds an element to the front of the deque.'
+Subjects:
+  - 'Computer Science'
+  - 'Game Development'
+Tags:
+  - 'Containers'
+  - 'OOP'
+  - 'Classes'
+  - 'Deques'
+CatalogContent:
+  - 'learn-c-plus-plus'
+  - 'paths/computer-science'
+---
+
+In C++, the **`.push_front()`** [method](https://www.codecademy.com/resources/docs/cpp/methods) inserts an element at the front of the deque, pushing existing elements toward the back.
+
+## Syntax
+
+```pseudo
+dequeName.push_front(value);
+```
+
+- `value`: The element added to the front of the deque. It must match the [data type](https://www.codecademy.com/resources/docs/cpp/data-types) stored in `dequeName`.
+
+## Example
+
+The example below uses `.push_front()` to place new values at the front of a deque:
+
+```cpp
+#include <iostream>
+#include <deque>
+
+int main() {
+  std::deque<int> numbers = {20, 30};
+
+  // Add elements to the front of the deque
+  numbers.push_front(10);
+  numbers.push_front(5);
+
+  std::cout << "Deque contents: ";
+
+  for (int num : numbers) {
+    std::cout << num << ' ';
+  }
+
+  std::cout << std::endl;
+
+  return 0;
+}
+```
+
+The above code produces the following output:
+
+```shell
+Deque contents: 5 10 20 30
+```
+
+## Codebyte
+
+This codebyte moves new tasks to the front of the deque with `.push_front()`:
+
+```codebyte/cpp
+#include <iostream>
+#include <deque>
+#include <string>
+
+int main() {
+  std::deque<std::string> tasks = {"review code", "write tests"};
+
+  tasks.push_front("update docs");
+  tasks.push_front("sync repo");
+
+  for (const auto& task : tasks) {
+    std::cout << task << std::endl;
+  }
+}
+```


### PR DESCRIPTION
### Description

Introduces a new markdown file explaining the .push_front() method for C++ deques, including syntax, examples, and a codebyte demonstrating usage.

### Issue Solved

<!--

Closes #7654 

-->

### Type of Change

- Updating the documentation

### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [ ] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ ] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ ] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

