### PR TITLE
Add .push_front() term entry for C++ deque (Issue #7654)

### DIFF
--- a/content/cpp/concepts/deque/terms/push-front/push-front.md
+++ b/content/cpp/concepts/deque/terms/push-front/push-front.md
@@ -1,0 +1,86 @@
+---
+Title: '.push_front()'
+Description: 'Adds an element to the beginning of the deque.'
+Subjects:
+  - 'Computer Science'
+  - 'Game Development'
+Tags:
+  - 'Arrays'
+  - 'Data Structures'
+  - 'Deques'
+  - 'Methods'
+CatalogContent:
+  - 'learn-c-plus-plus'
+  - 'paths/computer-science'
+---
+
+In C++, the `.push_front()` [method](https://www.codecademy.com/resources/docs/cpp/methods) adds an element to the beginning of the deque.
+
+## Syntax
+
+```pseudo
+dequeName.push_front(value);
+```
+
+- `value`: The element to be added to the front of the deque. It can be of any [data type](https://www.codecademy.com/resources/docs/cpp/data-types) that the `dequeName` holds.
+
+## Example
+
+The example below showcases the use of the `.push_front()` method:
+
+```cpp
+#include <iostream>
+#include <deque>
+
+int main() {
+  // Create a deque of integers
+  std::deque<int> numbers;
+
+  // Use .push_front() to add elements to the beginning of the deque
+  numbers.push_front(30);
+  numbers.push_front(20);
+  numbers.push_front(10);
+
+  // Display the elements of the deque
+  std::cout << "Deque contents: ";
+  for (int num : numbers) {
+    std::cout << num << " ";
+  }
+  std::cout << std::endl;
+
+  return 0;
+}
+```
+
+The above code generates the following output:
+
+```shell
+Deque contents: 10 20 30
+```
+
+## Codebyte Example
+
+The following codebyte adds several values to `myDeque` with the `.push_front()` method:
+
+```codebyte/cpp
+#include <iostream>
+#include <deque>
+
+int main() {
+  std::deque<int> myDeque;
+
+  // Add elements to the front of the deque
+  myDeque.push_front(100);
+  myDeque.push_front(200);
+  myDeque.push_front(300);
+
+  // Display the deque
+  std::cout << "Deque elements: ";
+  for (int element : myDeque) {
+    std::cout << element << " ";
+  }
+  std::cout << std::endl;
+
+  return 0;
+}
+```


### PR DESCRIPTION
### Description

This PR adds a new term entry for the `.push_front()` method under C++ deque. The entry includes:
- A description of the method
- Syntax section with parameter details
- Example section with working code and output
- Codebyte example with interactive code

The new entry is located at `content/cpp/concepts/deque/terms/push-front/push-front.md`.

### Issue Solved

Closes #7654

### Type of Change

- Adding a new entry

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.